### PR TITLE
feat:fix/tags

### DIFF
--- a/src/components/TaskCard/TaskCard.tsx
+++ b/src/components/TaskCard/TaskCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PriorityBadge from "./PriorityBadge";
 import type { ExtendedTask } from "../types/task";
+import { TaskCategoryLabel } from "./TaskCategoryLabel";
 import { getDeadlineStatus } from "../../utils/dateUtils";
 
 interface TaskCardProps {
@@ -130,9 +131,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
       {/* 2列目 優先度 + タグ */}
       <div className="flex items-center gap-3 mb-3">
         <PriorityBadge priority={task.priority} />
-        <span className="text-xs text-blue-600 bg-white bg-opacity-30 px-2 py-1 rounded-xl border border-blue-600 ">
-          #{task.taskCategory}
-        </span>
+        <TaskCategoryLabel categories={task.taskCategory} />
         {/* 残り日数タグ（完了タスク以外で表示） */}
         {task.taskStatus !== 'done' && (
           <span className={`text-xs px-2 py-1 rounded-xl border ${deadlineStyles.tagStyle}`}>

--- a/src/components/TaskCard/TaskCategoryLabel.tsx
+++ b/src/components/TaskCard/TaskCategoryLabel.tsx
@@ -1,0 +1,17 @@
+// components/TaskCategoryLabel.tsx
+import type{ TaskCategory } from '../types/task';
+
+type Props = { categories: TaskCategory[] };
+
+export const TaskCategoryLabel = ({ categories }: Props) => (
+<div className="flex flex-wrap gap-1">
+    {categories.map((c) => (
+        <span
+        key={c}
+        className="text-xs text-blue-600 bg-white bg-opacity-30 px-2 py-1 rounded-xl border border-blue-600"
+        >
+        #{c}
+        </span>
+    ))}
+    </div>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/Engineer-Task-APP/',
+  base: '/',
   css: {
     postcss: './postcss.config.js',
   },


### PR DESCRIPTION
・URLの変更による画面の表示されない不具合の修正(URLを以前の'/'に修正)
・カテゴリタグの#solo #team #frontなどの表示の連結を解除
・選択について、soloとteamはデフォルトでc絵h区されているように変更する必要性あり(最優先ではない)