### PR TITLE
fix: プロジェクト管理画面アクセス権限とプロジェクト参加機能の修正

### DIFF
--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState,useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import Sidebar from "../Sidebar/Sidebar";
 import TaskModal from "../TaskModal/TaskModal";
@@ -7,6 +7,7 @@ import { useTasks } from "../../hooks/useTasks";
 import { logout } from "../../services/authService";
 import { useProject } from "../../contexts/ProjectContext";
 import { useAuth } from "../../hooks/useAuth";
+import { isProjectAdmin } from "../../services/adminService";
 import type { ExtendedTask, NewTaskUI } from "../types/task";
 import type { SidebarItem } from "../types/sidebar";
 import type { OutletContextType } from "../types/outletContext";
@@ -14,14 +15,41 @@ import type { OutletContextType } from "../types/outletContext";
 const MainLayout : React.FC = () =>{
   const location = useLocation();
   const navigate = useNavigate();
-  const { selectedProject, clearSelectedProject } = useProject();
-  const { user, role } = useAuth();
+  const { selectedProject, selectedProjectId, clearSelectedProject } = useProject();
+  const { user } = useAuth();
   const { 
     tasks, addTask, deleteTask, toggleTaskStatus, updateTask, setFilter, currentFilter} = useTasks();
 
+  // プロジェクト管理者フラグ（プロジェクトメンバーテーブルのロールから取得）
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const [adminCheckLoading, setAdminCheckLoading] = useState<boolean>(true);
 
-  // サイドバーの配列
-  const sidebarItems: SidebarItem[] = [
+  // 選択されているプロジェクトでユーザーが管理者かをチェック
+  useEffect(() => {
+    const checkAdminStatus = async () => {
+      if (!selectedProjectId || !user?.id) {
+        setIsAdmin(false);
+        setAdminCheckLoading(false);
+        return;
+      }
+
+      try {
+        setAdminCheckLoading(true);
+        const adminStatus = await isProjectAdmin(selectedProjectId, user.id);
+        setIsAdmin(adminStatus);
+      } catch (error) {
+        console.error('管理者権限チェックエラー:', error);
+        setIsAdmin(false);
+      } finally {
+        setAdminCheckLoading(false);
+      }
+    };
+
+    checkAdminStatus();
+  }, [selectedProjectId, user?.id]);
+
+  // サイドバーの配列（isAdminとadminCheckLoadingに依存）
+  const sidebarItems: SidebarItem[] = useMemo(() => [
     { 
       id: "solo-task", 
       label: "Solo Task", 
@@ -61,11 +89,11 @@ const MainLayout : React.FC = () =>{
       id: "admin", 
       label: "Admin", 
       path: "/admin",
-      disabled: role !== "admin",
+      disabled: !isAdmin || adminCheckLoading,
       disabledReason: "管理者権限が必要です",
       icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>'
     },
-  ];
+  ], [isAdmin, adminCheckLoading]);
 
   // アクティブアイテムIDを計算
   const activeItemId = sidebarItems.find(item => item.path === location.pathname)?.id || location.pathname.replace("/","");

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -128,19 +128,50 @@ export const addProjectMember = async (
   userId: string,
   role: 'admin' | 'member' = 'member'
 ): Promise<ProjectMember> => {
-  const { data, error } = await supabase
-    .from('project_members')
-    .insert({
-      project_id: projectId,
-      user_id: userId,
-      role,
-      is_active: true,
-    })
-    .select()
-    .single();
+  try {
+    const { data, error } = await supabase
+      .from('project_members')
+      .insert({
+        project_id: projectId,
+        user_id: userId,
+        role,
+        is_active: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
 
-  if (error || !data) throw error || new Error('メンバー追加に失敗しました');
-  return data as ProjectMember;
+    if (error) {
+      // 重複キーエラー（既にメンバーとして存在する場合）の処理
+      if (error.code === '23505') {
+        console.log('ユーザーは既にプロジェクトメンバーです');
+        // 既存のメンバー情報を取得
+        const { data: existingMember, error: fetchError } = await supabase
+          .from('project_members')
+          .select('*')
+          .eq('project_id', projectId)
+          .eq('user_id', userId)
+          .single();
+        
+        if (fetchError || !existingMember) {
+          throw new Error('メンバー情報の取得に失敗しました');
+        }
+        return existingMember as ProjectMember;
+      }
+      console.error('プロジェクトメンバー追加エラー:', error);
+      throw error;
+    }
+
+    if (!data) {
+      throw new Error('メンバー追加に失敗しました');
+    }
+
+    return data as ProjectMember;
+  } catch (err) {
+    console.error('addProjectMember エラー:', err);
+    throw err;
+  }
 };
 
 /**


### PR DESCRIPTION
- MainLayout.tsx: ユーザーテーブルのロールではなくプロジェクトメンバーテーブルのロールで管理画面アクセス権限をチェックするように修正
- adminService.ts: addProjectMember関数にcreated_atとupdated_atを追加し、重複キーエラー時の処理を改善